### PR TITLE
Add actual deaths from NY Times data.

### DIFF
--- a/app.py
+++ b/app.py
@@ -29,6 +29,12 @@ def load_projections():
 
     return df
 
+def load_actuals():
+
+    df = pd.read_csv(os.path.join('data', 'nytimes_cases.csv'))
+
+    return df
+
 def filter_df(df, model, location, metric, start_date, end_date):
     dff = df.copy()
     dff = dff[
@@ -41,7 +47,33 @@ def filter_df(df, model, location, metric, start_date, end_date):
         ]
     return dff
 
+def add_actual_deaths(df, location, metric, start_date, end_date):
+    cases_df = df_cases.rename(columns={
+        'daily_deaths': 'deaths_mean'
+    })
+
+    cases_df = cases_df[
+        (cases_df.location_name == location) &
+        (cases_df.date > '2020-02-15') &
+        (cases_df.date < '2020-07-15')
+    ]
+
+    cases_df['deaths_upper'] = cases_df['deaths_mean']
+    cases_df['deaths_lower'] = cases_df['deaths_mean']
+
+    cases_df['model_name'] = 'NY TIMES'
+    cases_df['model_version'] = ''
+    cases_df['model_label'] = 'Actual'
+
+    for col in df.columns:
+        if col not in cases_df.columns:
+            cases_df[col] = np.nan
+
+    return pd.concat([df, cases_df])
+
 df = load_projections()
+
+df_cases = load_actuals()
 
 #initialize app
 app = dash.Dash(
@@ -228,6 +260,9 @@ def make_primary_graph(model, location, metric, start_date, end_date):
     dff = filter_df(df, model, location, metric, start_date, end_date)
 
     dff['model_label'] = dff['model_date'].dt.strftime("%m/%d").str[1:]
+
+    if 'death' in metric.lower():
+        dff = add_actual_deaths(dff, location, metric, start_date, end_date)
 
     plot_title = f'{model} - {location} - {ihme_column_translator[metric]}'
     num_models = len(dff.model_version.unique())

--- a/projections-scraper.py
+++ b/projections-scraper.py
@@ -16,6 +16,14 @@ import re
 import itertools
 import zipfile
 
+NYTIMES_STATE_URL = ('https://github.com/nytimes/covid-19-data/raw/master/us-states.csv')
+
+def fetch_df(url):
+    """Fetches a Pandas DataFrame from a remote source"""
+    r = requests.get(url)
+    return pd.read_csv(io.BytesIO(r.content))
+
+
 def get_date_list(min_date):
     '''
     generates list of dates from today backwards to min_date
@@ -110,15 +118,41 @@ def get_ihme_df():
         df['model_version'] = model_version
      #     df = pd.read_csv(z.open('hospitalization_all_locs_corrected.csv'))
         df_list.append(df)
-        
+
         time.sleep(0.2)
-        
+
     if len(df_list) > 0:
         df = pd.concat(df_list).drop(columns=['V1','Unnamed: 0','location']) #drop problematic columns
-        df['location_name'] = np.where(df['location_name'] == 'US', 'United States of America', df['location_name']) 
+        df['location_name'] = np.where(df['location_name'] == 'US', 'United States of America', df['location_name'])
         df.to_csv(os.path.join('data','ihme_compiled.csv'), index=False)
 
+def get_nytimes_df():
+    print('processing: NY Times case data.')
+
+    df = fetch_df(NYTIMES_STATE_URL)
+
+    # Add 'daily_deaths' column. Drops first date of data.
+    df['dt'] = pd.to_datetime(df['date'])
+    df['prev_dt'] = df['dt'] - pd.to_timedelta(1, unit='d')
+    df_merged = df.merge(df[['state', 'dt', 'deaths']],
+                     left_on=['state', 'prev_dt'],
+                     right_on=['state', 'dt'],
+                     suffixes=('', '_y'))
+    df_merged['daily_deaths'] = df_merged['deaths'] - df_merged['deaths_y']
+    df = df_merged.drop(columns=['dt', 'prev_dt', 'dt_y', 'deaths_y'])
+
+    # Add USA totals
+    df_us = df.groupby('date')[['cases', 'deaths', 'daily_deaths']].sum().reset_index()
+    df_us['state'] = 'United States of America'
+    df_us['fips'] = 0
+    df = pd.concat([df, df_us])
+
+    # Rename state to location_name
+    df = df.rename(columns={'state': 'location_name'})
+
+    df.to_csv(os.path.join('data', 'nytimes_cases.csv'))
 
 if __name__ == "__main__":
     get_lanl_df()
     get_ihme_df()
+    get_nytimes_df()


### PR DESCRIPTION
This adds NY Times case data to the project scraping script as well as the graphs in the Dash app. 

Adds only daily death actuals if the selected metric contains the word 'death'.

e.g. NY data:
![Screen Shot 2020-04-15 at 12 14 51 AM](https://user-images.githubusercontent.com/2320142/79299525-48454880-7eb2-11ea-8b66-6f0dfbfe402a.png)


Fixes #3 