### PR TITLE
Add COVID Tracking Project as a data source

### DIFF
--- a/column_translater.py
+++ b/column_translater.py
@@ -34,4 +34,35 @@ ihme_column_translator = {
     'icuover_upper': 'ICU Beds Shortage (Upper)',
 }
 
-    
+imhe_to_covidtracking = {
+    # mean
+    'allbed_mean': 'hospitalizedCurrently',
+    'ICUbed_mean': 'inIcuCurrently',
+    'InvVen_mean': 'onVentilatorCurrently',
+    'deaths_mean': 'deathIncrease',
+    'admis_mean': 'hospitalizedIncrease',
+    'newICU_mean': 'inIcuIncrease',
+    'totdea_mean': 'death',
+    'bedover_mean': None,
+    'icuover_mean': None,
+    # lower
+    'allbed_lower': 'hospitalizedCurrently',
+    'ICUbed_lower': 'inIcuCurrently',
+    'InvVen_lower': 'onVentilatorCurrently',
+    'deaths_lower': 'deathIncrease',
+    'admis_lower': 'hospitalizedIncrease',
+    'newICU_lower': 'inIcuIncrease',
+    'totdea_lower': 'death',
+    'bedover_lower': None,
+    'icuover_lower': None,
+    # upper
+    'allbed_upper': 'hospitalizedCurrently',
+    'ICUbed_upper': 'inIcuCurrently',
+    'InvVen_upper': 'onVentilatorCurrently',
+    'deaths_upper': 'deathIncrease',
+    'admis_upper': 'hospitalizedIncrease',
+    'newICU_upper': 'inIcuIncrease',
+    'totdea_upper': 'death',
+    'bedover_upper': None,
+    'icuover_upper': None,
+}


### PR DESCRIPTION
Hey,

Thanks for creating this project, it looks really useful! This PR adds the COVID Tracking Project as a source for data (related to request in #3), and adds mappings between the IHME projected quantities and the real quantities that COVID Tracking reports ([API info](https://covidtracking.com/api)). I just set it to draw the real line in red if there is data for the selected metric (not really familiar with plotly).

1. The "allbed_*" IHME metrics I assume correspond to the currently used hospital beds of all types (hospitalizedCurrently in COVID Tracking's data) but maybe you can confirm that.
2. All Beds Shortage and ICU Beds Shortage - no real data for this available from COVID Tracking. Could potentially calculate it as (Current beds) - (the bed capacity that the model implies).
3. On the topic of ICU beds, COVID Tracking has the cumulative number of ICU admissions (which would give a real number for comparison to the daily new ICU patients that IHME predicts), but only a few states are reporting it consistently, so the data is clearly inaccurate and not useful at all.

On the whole, I think their data does a great job covering most of the metrics for the US, including state level. I was looking for similar data for the world, but I'm not sure if it's collected anywhere. JHU has worldwide data (here)[https://github.com/CSSEGISandData/COVID-19/tree/master/csse_covid_19_data/csse_covid_19_daily_reports], but it seems to track only confirmed, active, recovered, and deceased case numbers. If you know of good sources for more fine-grain data in other countries, I'm happy to help with integrating those, or happy to pitch in on whatever else!