### PR TITLE
Fix Github footer link

### DIFF
--- a/app.py
+++ b/app.py
@@ -248,7 +248,7 @@ app.layout = dbc.Container(
                                         align="center",
                                         no_gutters=True,
                                     ),
-                                    href="https://twitter.com/CovidProjection",
+                                    href="https://github.com/yuorme/covid-projections",
                                 ),
                             width="auto"
                             )


### PR DESCRIPTION
Just noticed that the Github logo in the footer accidentally links to Twitter instead of Github