### PR TITLE
Add google analytics by editing the app index string

### DIFF
--- a/app.py
+++ b/app.py
@@ -117,6 +117,30 @@ server = app.server #need this for heroku - gunicorn deploy
 # This forces https for the site
 Talisman(app.server, content_security_policy=None)
 
+app.index_string = '''
+<!DOCTYPE html>
+<html>
+    <head>
+        {%metas%}
+        <title>{%title%}</title>
+        {%favicon%}
+        {%css%}
+        <script>
+        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+        ga('create', 'UA-164558144-1', 'auto');
+        ga('send', 'pageview');
+        </script>
+    </head>
+    <body>
+        {%app_entry%}
+        <footer>
+            {%config%}
+            {%scripts%}
+            {%renderer%}
+        </footer>
+    </body>
+</html>
+'''
 
 collapse_plot_options = html.Div(
             [


### PR DESCRIPTION
Stole the idea of [injecting the script in the index_string](https://github.com/plotly/dash-sample-apps/blob/7dd504911f9bc092e809aaafe26d8f3aeadc379d/predeploy.py) from the sample dash apps. I've tested on staging and it is loading google analytics, but I suggest double-checking in the GA dashboard that it's sending page views successfully.