### PR TITLE
Store data client-side to speed up graph updates

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,9 +1,7 @@
 import os
-from dotenv import load_dotenv
-load_dotenv()
 
 app_config = {
-    'debug' : True, #Set flask debug mode: True for development, False for production
+    'debug' : False, #Set flask debug mode: True for development, False for production
     'sqlalchemy_database_uri' : f'postgresql+psycopg2://postgres:{os.environ.get("COVID_PRED_POSTGRES_PASS")}@'\
                                     f'{os.environ.get("COVID_PRED_RDS_URL")}/covid_projections?sslmode=verify-ca'\
                                 f'&sslrootcert=rds-ca-2019-root.pem',

--- a/config.py
+++ b/config.py
@@ -1,7 +1,9 @@
 import os
+from dotenv import load_dotenv
+load_dotenv()
 
 app_config = {
-    'debug' : False, #Set flask debug mode: True for development, False for production
+    'debug' : True, #Set flask debug mode: True for development, False for production
     'sqlalchemy_database_uri' : f'postgresql+psycopg2://postgres:{os.environ.get("COVID_PRED_POSTGRES_PASS")}@'\
                                     f'{os.environ.get("COVID_PRED_RDS_URL")}/covid_projections?sslmode=verify-ca'\
                                 f'&sslrootcert=rds-ca-2019-root.pem',


### PR DESCRIPTION
This PR stores data on the webpage to avoid requesting the data when the user toggles the semi-log plot option or toggles the actual data option. 